### PR TITLE
Refactor schemas to use refs

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -1,14 +1,8 @@
 var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
 
 var commentSchema = new mongoose.Schema({
-  user_id: {
-    type: String,
-    required: true
-  },
-  userName: {
-    type: String,
-    required: true
-  },
+  author: { type: Schema.Types.ObjectId, ref: 'User' },
   body: {
     type: String,
     required: true

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -1,9 +1,11 @@
 var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
 
 //requires the comment schema
 var Comment = require('./comments.js')
 
 var postSchema = new mongoose.Schema({
+  author: { type: Schema.Types.ObjectId, ref: 'User' },
   pictures: {
     type: String,
     required: true
@@ -16,7 +18,7 @@ var postSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  comments: [Comment.schema],
+  comments: [{type: Schema.Types.ObjectId, ref: 'Comment' }],
   haters: [String]
 });
 

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
 
 var Post = require('./posts.js');
 
@@ -23,7 +24,7 @@ var userSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  posts: [Post.schema]
+  posts: [{ type: Schema.Types.ObjectId, ref: 'Post' }]
 
 });
 

--- a/scripts/seed-posts.js
+++ b/scripts/seed-posts.js
@@ -23,24 +23,34 @@ async.series([
         function(error, user) {
           //If user.posts is falsy
           //Create an array for user posts
-          console.log(user);
           if (error) {
             console.error(error);
-          } else
+          }
           if (!user.posts) {
-            console.log('adding empty array');
             user.posts = [];
           }
-          debugger;
-          console.log(user.posts);
-          user.posts.push({
+          post = new Post({
+            author: user._id,
             pictures: 'http://i.imgur.com/ufx7hP0.jpg',
             pubDate: '150623',
             caption: 'Worst day ever.',
             haters: ['832fysz']
           });
-          user.save(done);
+
+          post.save(function(err){
+            if(err){
+              console.error(err);
+            }
+            user.posts.push(post._id);
+            user.save(function(err){
+              if(err){
+                console.error(err);
+              }
+              done();
+            });
+          });
         });
+
     }
   ],
 


### PR DESCRIPTION
Refactor schemas to use refs instead of nested schemas
Change seed-posts.js and seed-users.js to reflect new schemas
